### PR TITLE
make sure, repository configurations are not part of the release-tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# don't include repository configuration in the releases
+# as created by 'git archive'
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
the current release-tarballs include '.gitignore' files in a non-git repository.
this is at best useless, but might create problems on the receiving side.

since the release-tarballs are created with "git archive", it is possible to not include selected files.

this patch, makes sure that no repository-configuration files (.gitignore, but also this .gitattributes) are part of the tarball.
it also excludes .travis-yml, in case you ever want to setup a CI :-)