### PR TITLE
Pd64 and pd_error()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,27 @@ set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
+if(APPLE)
+  set(pdext ".pd_darwin")
+elseif(WIN32)
+  set(pdext ".dll")
+else()
+  set(pdext ".pd_linux")
+endif()
+
+set (PD_EXTENSION "${pdext}" CACHE STRING "the external extension (.pd_linux, .linux_amd64_64.so)")
+
+
 find_path(PD_HEADER_PATH m_pd.h HINTS ${CMAKE_SOURCE_DIR}/src)
 find_library(PD_LIBRARY pd.dll)
 find_package(CSOUND)
 
 if(PD_HEADER_PATH)
-    if(APPLE) 
-        set(pdname "csound6~.pd_darwin")
-    elseif(WIN32)
-      set(pdname "csound6_tilde.dll")
+    if(WIN32)
+      set(pdname "csound6_tilde${PD_EXTENSION}")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_WIN32 -D__x86_64__")
     else()
-       set(pdname "csound6~.pd_linux")
+       set(pdname "csound6~${PD_EXTENSION}")
     endif()
     add_library(pdcsound MODULE src/csoundapi_tilde.c)
     target_include_directories(pdcsound PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,19 @@ else()
 endif()
 
 set (PD_EXTENSION "${pdext}" CACHE STRING "the external extension (.pd_linux, .linux_amd64_64.so)")
+set (PD_FLOATSIZE 32 CACHE STRING "the floatsize of Pd (32 or 64)")
+
+if(PD_FLOATSIZE STREQUAL 64)
+  add_definitions(-DPD_FLOATSIZE=64)
+  # TODO check if the extension matches ".*_*_64.*"
+  if(NOT PD_EXTENSION MATCHES "^\.[^.]*_[^.]*_64\.[^.]*$")
+    message(FATAL_ERROR " double-precision externals must have an extension like '.linux_amd64_64.so'")
+  endif()
+elseif(PD_FLOATSIZE STREQUAL 32)
+else()
+  message(FATAL "FLOATSIZE must be 32 or 64")
+endif()
+
 
 
 find_path(PD_HEADER_PATH m_pd.h HINTS ${CMAKE_SOURCE_DIR}/src)

--- a/src/csoundapi_tilde.c
+++ b/src/csoundapi_tilde.c
@@ -37,15 +37,6 @@
 #define MIDI_QUEUE_MAX 1024
 #define MIDI_QUEUE_MASK 1023
 
-static void error(const char *fmt,...) {
-    char string[1024];
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(string, 1024, fmt, args);
-    post("error: %s", string);
-    va_end(args);
-}  
-
 static t_class *csoundapi_class = 0;
 
 typedef struct _channelname {
@@ -778,7 +769,7 @@ static int open_midi_callback(CSOUND *cs, void **userData, const char *dev)
     t_csoundapi *x = (t_csoundapi *) csoundGetHostData(cs);
     midi_queue *mq = (midi_queue *) malloc(sizeof(midi_queue));
     if (mq == NULL) {
-      error("unable to allocate memory for midi queue");
+      pd_error(x, "unable to allocate memory for midi queue");
       return -1;
     }
     mq->writep = mq->readp = 0;
@@ -840,7 +831,7 @@ static int read_midi_callback(CSOUND *cs, void *userData,
 #define MIDI_COMMAND(N, M)                              \
   mm = ((int) N) - 1;                                   \
   if ((mm & 0x0f) != mm) {                              \
-    error("midi channel out of range: %d", mm + 1);     \
+    pd_error(x, "midi channel out of range: %d", mm + 1);     \
     return;                                             \
   }                                                     \
   val[wp++] = (mm | M);
@@ -848,7 +839,7 @@ static int read_midi_callback(CSOUND *cs, void *userData,
 #define MIDI_DATA(N, M, S)                      \
   mm = (int) N;                                 \
   if ((mm & M) != mm) {                         \
-    error("midi " S " out of range: %d", mm);   \
+    pd_error(x, "midi " S " out of range: %d", mm);   \
     return;                                     \
   }                                             \
   val[wp++ & MIDI_QUEUE_MASK] = mm;
@@ -863,7 +854,7 @@ static void csoundapi_midi(t_csoundapi *x, t_symbol *s, int argc, t_atom *argv)
     int i;
     for(i = 0; i<argc; i++) {
       if (argv[i].a_type != A_FLOAT) {
-        error("midi parameter of wrong type");
+        pd_error(x, "midi parameter of wrong type");
         return;
       }
       MIDI_DATA(atom_getfloat(&argv[i]), 0xff, "value");


### PR DESCRIPTION
this PR fixes two issues:
- #11 
- #9 

### double precision external

as discussed in #11, the missing bits for Pd64 were
- a simple way to enable a double-precision build. this can now be done by calling cmake with `-DPD_FLOATSIZE=64`
- a simple way to set the proper filename extension. rather than trying to guess the extension, you can now specify it via `-DPD_EXTENSION=.d_fat`
   (if double-precision is enabled, the extension *must* follow the `.<os>-<cpu>-<floatsize>.<ext>` pattern, wth `<floatsize>` being 64. this is enforced with a simple regexp in the CMakeLists.txt)


### `pd_error()` vs `error()`

`error()` has been removed from Pd because of nameclash issues. @vlazzarini resolved the missing symbol by providing their own `error()` implementation in 3790d561988373f9a3a9bcf11d488df5d5d107c8
the proper (from a Pd POV) solution, is to use the `pd_error()` function instead, which has the added benefit of making errors trackable.
